### PR TITLE
Remove background images redundancy

### DIFF
--- a/project/examples/css/ex6.css
+++ b/project/examples/css/ex6.css
@@ -53,6 +53,7 @@ nav a {
 -----------------------------------------*/
 .home {
   background: url(../images/background-6.jpg);
+  background-position: center center;
   background-size: cover;
 }
 

--- a/project/examples/css/ex6.css
+++ b/project/examples/css/ex6.css
@@ -50,9 +50,9 @@ nav a {
 }
 
 /* HOME PAGE STYLES
------------------------------------------*/ 
+-----------------------------------------*/
 .home {
-  background: url(../images/background-6.jpg) no-repeat 50%;
+  background: url(../images/background-6.jpg);
   background-size: cover;
 }
 

--- a/project/examples/css/ex7.css
+++ b/project/examples/css/ex7.css
@@ -53,6 +53,7 @@ nav a {
 -----------------------------------------*/
 .home {
   background: url(../images/background-6.jpg);
+  background-position: center center;
   background-size: cover;
 }
 

--- a/project/examples/css/ex7.css
+++ b/project/examples/css/ex7.css
@@ -50,9 +50,9 @@ nav a {
 }
 
 /* HOME PAGE STYLES
------------------------------------------*/ 
+-----------------------------------------*/
 .home {
-  background: url(../images/background-6.jpg) no-repeat 50%;
+  background: url(../images/background-6.jpg);
   background-size: cover;
 }
 

--- a/project/final/css/final.css
+++ b/project/final/css/final.css
@@ -66,6 +66,7 @@ nav a {
 -----------------------------------------*/ 
 .home {
   background: url(../images/background-6.jpg);
+  background-position: center center;
   background-size: cover;
 }
 

--- a/project/final/css/final.css
+++ b/project/final/css/final.css
@@ -65,7 +65,7 @@ nav a {
 /* HOME PAGE STYLES
 -----------------------------------------*/ 
 .home {
-  background: url(../images/background-6.jpg) no-repeat 50%;
+  background: url(../images/background-6.jpg);
   background-size: cover;
 }
 

--- a/slides.html
+++ b/slides.html
@@ -2157,14 +2157,14 @@ text-transform: lowercase;</textarea>
         ```
         /* shorthand */
         .home {
-          background: url(../images/background-6.jpg) no-repeat 50%; 
+          background: url(../images/background-6.jpg) no-repeat center center;
         }
 
         /* longhand */
         .home {
           background-image: url(../images/background-6.jpg); 
           background-repeat: no-repeat;
-          background-position: 50%;
+          background-position: center center;
         }
         ```
         
@@ -2193,7 +2193,7 @@ text-transform: lowercase;</textarea>
         .home {
           background-image: url(../images/background-6.jpg);
           background-repeat: no-repeat;
-          background-position: 50%;
+          background-position: center center;
           background-size: cover;
         }
         ```
@@ -2201,7 +2201,7 @@ text-transform: lowercase;</textarea>
         To include it using the shorthand property, there's a quirk. It _must_ be included after `background-position`, separated with the `/` character.  
         ```
         .home {
-          background: url(../images/background-6.jpg) no-repeat 50% / cover;
+          background: url(../images/background-6.jpg) no-repeat center center/ cover;
         }
         ```
       </script>
@@ -2232,7 +2232,8 @@ text-transform: lowercase;</textarea>
         
         ```
         .home {
-          background: url(../images/background-6.jpg) no-repeat;
+          background: url(../images/background-6.jpg);
+          background-size: center center;
           background-size: cover;
         }
         ```


### PR DESCRIPTION
You don't need to have no-repeat when the background-size is set to cover:
```
cover
A keyword that is the inverse of contain. Scales the image as large as possible and maintains image aspect ratio (image doesn't get squished). The image "covers" the entire width or height of the container. When the image and container have different dimensions, the image is clipped either left/right or top/bottom.
```
https://developer.mozilla.org/en/docs/Web/CSS/background-size?v=control

Also changed "50%" to "center center" for understandability.