### PR TITLE
Remove reference to image alt attributes being optional

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -863,11 +863,9 @@
       <script type="text/template">
         #The alt attribute
 
-        The `alt` attribute is optional and refers to *alternative text*. 
+        The `alt` attribute refers to *alternative text*.
         
-        Though it's optional, it is **strongly recommended** to include it for accessibility.
-        
-        The alt text is read by screen reading software used by visually impaired users and also displays if the image is missing. 
+        The alt text is read by screen reading software used by visually impaired users and also displays if the image is missing.
         
         It should be a short description of the image.
 


### PR DESCRIPTION
My previous pull request #13 was not accepted, but I noticed most of the changes were now made.
This is a new pull request with the remaining reference to image alt attributes being optional removed.