### PR TITLE
Added csss-a11y-plugin

### DIFF
--- a/framework/css/a11y/plugin.css
+++ b/framework/css/a11y/plugin.css
@@ -1,0 +1,77 @@
+/**
+ * CSSS Accessibility Plugin
+ *
+ * - Resets focus indicator to be visible on `Tab` key press
+ * - Removes `outline` on slide focus
+ * - Includes helper classes
+ *
+ * @author Scott Vinkle <scott.vinkle@shopify.com>
+ * @version 0.1.0
+ * @license MIT License
+ */
+
+/* Reset focus indicator styles */
+a:focus {
+  outline: 1px dotted #212121 !important;
+  outline: 5px auto -webkit-focus-ring-color !important;
+}
+
+/* Removes flash of focus indicator when slide receives focus */
+.slide[tabindex="-1"]:focus {
+  outline: none;
+}
+
+/* `.visuallyhidden` helper class definition
+   https://github.com/h5bp/html5-boilerplate/blob/master/dist/css/main.css#L141
+*/
+.visuallyhidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+/* `.focusable` helper class definition
+   https://github.com/h5bp/html5-boilerplate/blob/master/dist/css/main.css#L159
+*/
+.visuallyhidden.focusable:active,
+.visuallyhidden.focusable:focus {
+  clip: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  position: static;
+  white-space: inherit;
+  width: auto;
+}
+
+/* List styles */
+.a11y-controls__list {
+  bottom: 90px;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  right: 64px;
+}
+
+/* List item styles */
+.a11y-controls__item {
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+/* Reset list item `before` styles */
+.a11y-controls__item::before {
+  content: '';
+  margin: 0;
+  padding: 0;
+}

--- a/framework/scripts/plugins/a11y/plugin.js
+++ b/framework/scripts/plugins/a11y/plugin.js
@@ -1,0 +1,204 @@
+/**
+ * CSSS Accessibility Plugin
+ *
+ * Helps to make slides more keyboard and screen reader friendly by
+ * providing the following:
+ *
+ * - Sets `role` for each slide for semantic context
+ * - Sets `aria-roledescription` for each slide for extra context
+ * - Sets `aria-label` for each slide to provide an accessible name
+ * - Outputs a link list for keyboard controls to load previous and next slides
+ * - Shifts focus to slide content container on link click
+ *
+ * @author Scott Vinkle <scott.vinkle@shopify.com>
+ * @version 0.1.0
+ * @license MIT License
+ */
+
+(function() {
+  var self = (window.a11y = {
+    /**
+     * Set slides to be more screen reader friendly.
+     *
+     * @return null
+     */
+    setupSlides: function() {
+      // Check for `slideshow.slides` object
+      if (!window.slideshow.slides) {
+        return;
+      }
+
+      // Local slide object
+      var slide = {
+        all: window.slideshow.slides,
+        current: null,
+        index: 0,
+        next: null,
+        prev: null,
+        title: '',
+        total: window.slideshow.slides.length
+      };
+
+      // Iterarte over each slide available…
+      for (; slide.index < slide.total; slide.index++) {
+        // Cache current slide
+        slide.current = slide.all[slide.index];
+
+        // Previous slide
+        if (slide.index !== 0) {
+          slide.prev = slide.all[slide.index - 1];
+        }
+
+        // Next slide
+        slide.next = slide.all[slide.index + 1];
+
+        // Cache current slide title
+        slide.title = slide.current.getAttribute('data-title');
+
+        // Set current slide attributes
+        slide.current.setAttribute('role', 'region');
+        slide.current.setAttribute('aria-roledescription', 'slide');
+        slide.current.setAttribute('aria-label', slide.index + 1 + ' - ' + slide.title);
+
+        // Setup controls for current slide
+        self.slideControls(slide.current, slide.prev, slide.next);
+      }
+    },
+
+    /**
+     * Create and output the list of links for keyboard and screen reader
+     * users.
+     *
+     * @param {Element} currentSlide Slide `section` HTML element
+     * @param {Element} prevSlide Slide `section` HTML element
+     * @param {Element} nextSlide Slide `section` HTML element
+     * @return null
+     */
+    slideControls: function(currentSlide, prevSlide, nextSlide) {
+      // Create document fragment to hold list and controls
+      var fragment = document.createDocumentFragment();
+
+      // Create list and controls
+      var controls = {
+        list: document.createElement('ul'),
+        next: {
+          item: document.createElement('li'),
+          link: document.createElement('a')
+        },
+        prev: {
+          item: document.createElement('li'),
+          link: document.createElement('a')
+        },
+        strings: {
+          next: 'Next&nbsp;<span aria-hidden="true">&raquo;</span>',
+          nextAT: 'Next Slide',
+          previous: '<span aria-hidden="true">&laquo;</span>&nbsp;Previous',
+          previousAT: 'Previous Slide'
+        }
+      };
+
+      // List classes
+      controls.list.setAttribute('role', 'list');
+      controls.list.classList.add('a11y-controls__list');
+
+      // List items classes
+      controls.prev.item.classList.add('a11y-controls__item');
+      controls.next.item.classList.add('a11y-controls__item');
+
+      // Previous link classes
+      controls.prev.link.classList.add('a11y-controls__link');
+      controls.prev.link.classList.add('visuallyhidden');
+      controls.prev.link.classList.add('focusable');
+
+      // Next link classes
+      controls.next.link.classList.add('a11y-controls__link');
+      controls.next.link.classList.add('visuallyhidden');
+      controls.next.link.classList.add('focusable');
+
+      // Output previous link if available
+      if (prevSlide !== null) {
+        // Previous link attributes
+        controls.prev.link.href = '#' + prevSlide.id;
+        controls.prev.link.target = '_self';
+        controls.prev.link.innerHTML = controls.strings.previous;
+        controls.prev.link.setAttribute('aria-label', controls.strings.previousAT);
+
+        // Load previous slide on click
+        controls.prev.link.addEventListener('click', function() {
+          self.shiftFocus(prevSlide);
+        }, false);
+
+        // Output previous link within list item
+        controls.prev.item.appendChild(controls.prev.link);
+        controls.list.appendChild(controls.prev.item);
+      }
+
+      // Output next link if available
+      if (nextSlide !== undefined) {
+        // Next link attributes
+        controls.next.link.href = '#' + nextSlide.id;
+        controls.next.link.target = '_self';
+        controls.next.link.innerHTML = controls.strings.next;
+        controls.next.link.setAttribute('aria-label', controls.strings.nextAT);
+
+        // Load next slide on click
+        controls.next.link.addEventListener('click', function() {
+          self.shiftFocus(nextSlide);
+        }, false);
+
+        // Output next link within list item
+        controls.next.item.appendChild(controls.next.link);
+        controls.list.appendChild(controls.next.item);
+      }
+
+      // Output list and append to slide `section`
+      fragment.appendChild(controls.list);
+      currentSlide.appendChild(fragment);
+    },
+
+    /**
+     * Shift keyboard focus to the Slide on link click event. This helps
+     * to provide greater context for screen reader users for when a
+     * slide loads.
+     *
+     * @param {Element} slide Slide `section` HTML element
+     * @return null
+     */
+    shiftFocus: function(slide) {
+      var addFocus = function(callback) {
+        // Set `tabindex` on the slide in order for it to receive focus
+        slide.setAttribute('tabindex', -1);
+
+        // Send keyboard focus to the slide
+        slide.focus();
+
+        // Remove focus
+        callback();
+      }
+
+      var removeFocus = function() {
+        // Remove `tabindex` in order to not disrupt Slide keyboard navigation
+        slide.removeAttribute('tabindex');
+      }
+
+      addFocus(removeFocus);
+    },
+
+    /**
+     * Initialize the plugin by calling setupSlides method.
+     *
+     * @return null
+     */
+    init: function() {
+      // Check for `slideshow` object
+      if (!window.slideshow) {
+        return;
+      }
+
+      self.setupSlides();
+    }
+  });
+
+  // Initialize the plugin when page content has loaded
+  document.addEventListener('DOMContentLoaded', self.init);
+})();

--- a/slides.html
+++ b/slides.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="framework/css/fonts.css" data-noprefix>
   <link rel="stylesheet" href="framework/css/highlightjs/github.css" data-noprefix>
   <link rel="stylesheet" href="framework/css/styles.css" data-noprefix>
+  <link rel="stylesheet" href="framework/css/a11y/plugin.css" data-noprefix>
   <link rel="shortcut icon" href="framework/img/favicon.ico">
 
   <!-- Takes care of CSS3 prefixes -->
@@ -2870,7 +2871,7 @@ img {
 <script src="framework/scripts/plugins/markdown/markdown.js"></script>
 <script src="framework/scripts/plugins/highlight/highlight-8.4.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-<script src="framework/scripts/llc.js"></script>
+<script src="framework/scripts/plugins/a11y/plugin.js"></script>
 <script>
   var slideshow = new SlideShow();
 


### PR DESCRIPTION
## Changes
Added [csss-a11y-plugin](https://github.com/svinkle/csss-a11y-plugin) to help with general accessibility issues of the slide framework.

- People can now <kbd>Tab</kbd> through slides, see focus indicators around interactive elements, and eventually land on new "Next" and "Previous" links to load slides.
- When a slide is loaded, screen reader users will receive feedback that a slide has loaded as well as focus will be sent to the top of the slide for content discovery.
- Sighted users are still able to use the keyboard <kbd>Left</kbd> and <kbd>Right</kbd> arrow keys as expected

<details>
  <summary>Demo</summary>

  ![a11y-plugin](https://user-images.githubusercontent.com/1392632/58372659-f63cb280-7eee-11e9-8a90-96a28791b593.gif)
</details>
